### PR TITLE
docs: add task planning template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ secrets.json
 **/service-account.json
 worker/rest/templates/customScript.ts*
 !worker/rest/templates/customScript.ts.example
+
+# Local task documents
+/docs/tasks/**
+!/docs/tasks/TEMPLATE.md

--- a/docs/tasks/TEMPLATE.md
+++ b/docs/tasks/TEMPLATE.md
@@ -1,0 +1,68 @@
+# <Task title>
+
+> Copy this file to `docs/tasks/YYYY-MM-DD-<slug>.md`. Task documents are local working notes and are ignored by Git; only this template is tracked.
+
+## Requester input
+
+### Desired outcome
+
+<What should be true when this task is complete?>
+
+### Requirements
+
+- <Required behavior, deliverable, or constraint>
+- <Required behavior, deliverable, or constraint>
+
+### Acceptance criteria
+
+- [ ] <Observable condition that proves the task is complete>
+- [ ] <Observable condition that proves the task is complete>
+
+### Constraints and references
+
+- Constraints: <Compatibility, timing, deployment, or scope limits>
+- References: <Issues, PRs, files, URLs, screenshots, or examples>
+
+## Assistant working area
+
+### Scope of Work
+
+- Included: <Work required to satisfy the request>
+- Excluded: <Work intentionally outside this task>
+- Assumptions: <Assumptions to confirm or validate>
+- Dependencies and risks: <External prerequisites, blockers, or risks>
+
+### Specification
+
+<Describe affected interfaces, user-visible behavior, data/configuration changes, failure behavior, and compatibility requirements.>
+
+### Phased plan
+
+#### Discovery
+
+- [ ] <Inspect the relevant system and reproduce or validate the starting state>
+
+#### Implementation
+
+- [ ] <Make the minimal required change>
+
+#### Verification
+
+- [ ] <Run the command, test, or scenario that proves the acceptance criteria>
+
+### Decisions and changes
+
+| Date       | Decision or change | Reason   |
+| ---------- | ------------------ | -------- |
+| YYYY-MM-DD | <Decision>         | <Reason> |
+
+### Verification evidence
+
+- <Command or scenario>
+- <Observed result>
+
+### Handoff
+
+- Status: <Complete / blocked / cancelled>
+- Commit or PR: <Reference>
+- Follow-up: <None or explicit next task>


### PR DESCRIPTION
## Summary
- add a reusable task document template under docs/tasks
- separate requester requirements from assistant SoW, specification, phased plan, verification, and handoff
- ignore all task instances while keeping TEMPLATE.md tracked

## Verification
- pnpm exec prettier --check docs/tasks/TEMPLATE.md
- git diff --check
- git check-ignore -q docs/tasks/example-task.md